### PR TITLE
 缓存优化以及bug修复

### DIFF
--- a/ruoyi-admin/src/main/java/com/ruoyi/web/controller/common/CaptchaController.java
+++ b/ruoyi-admin/src/main/java/com/ruoyi/web/controller/common/CaptchaController.java
@@ -33,9 +33,6 @@ public class CaptchaController
 
     @Resource(name = "captchaProducerMath")
     private Producer captchaProducerMath;
-
-    /*@Autowired
-    private RedisCache redisCache;*/
     
     @Autowired
     private ISysConfigService configService;
@@ -75,7 +72,7 @@ public class CaptchaController
             image = captchaProducer.createImage(capStr);
         }
 
-        CacheUtils.putCache(verifyKey, code, Constants.CAPTCHA_EXPIRATION, TimeUnit.MINUTES);
+        CacheUtils.putCacheObject(verifyKey, code, Constants.CAPTCHA_EXPIRATION, TimeUnit.MINUTES, Constants.CAPTCH_EHCACHE);
         
         // 转换流信息写出
         FastByteArrayOutputStream os = new FastByteArrayOutputStream();

--- a/ruoyi-admin/src/main/resources/application.yml
+++ b/ruoyi-admin/src/main/resources/application.yml
@@ -47,7 +47,7 @@ user:
   password:
     # 密码最大错误次数
     maxRetryCount: 5
-    # 密码锁定时间（默认10分钟）
+    # 密码锁定时间（默认10分钟,若修改需要更新ehCache.xml的pwdErrCntCache过期时间）
     lockTime: 10
 
 # Spring配置
@@ -106,7 +106,7 @@ token:
     header: Authorization
     # 令牌密钥
     secret: abcdefghijklmnopqrstuvwxyz
-    # 令牌有效期（默认30分钟）
+    # 令牌有效期（默认30分钟）若修改需要更新ehCache.xml的tokenCache过期时间
     expireTime: 30
   
 # MyBatis配置

--- a/ruoyi-admin/src/main/resources/ehcache.xml
+++ b/ruoyi-admin/src/main/resources/ehcache.xml
@@ -2,6 +2,20 @@
 <ehcache xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="http://ehcache.org/ehcache.xsd"
          updateCheck="false">
+    <!--
+       maxElementsInMemory：缓存中允许创建的最大对象数
+       eternal：缓存中对象是否为永久的，如果是，超时设置将被忽略，对象从不过期。
+       timeToIdleSeconds：缓存数据空闲的最大时间，也就是说如果有一个缓存有多久没有被访问就会被销毁， 如果该值是 0 就意味着元素可以停顿无穷长的时间。
+       timeToLiveSeconds：缓存数据存活的时间，缓存对象最大的的存活时间，超过这个时间就会被销毁， 这只能在元素不是永久驻留时有效，如果该值是0就意味着元素可以停顿无穷长的时间。
+       timeToIdleSeconds，timeToLiveSeconds2个参数，一个为0，只看另外一个。2个都不为0，2个条件都要满足！【只看此条】
+       overflowToDisk：配置此属性，当内存中Element数量达到maxElementsInMemory时，Ehcache将会Element写到磁盘中。
+       memoryStoreEvictionPolicy：缓存满了之后的淘汰算法。
+       maxElementsOnDisk 磁盘中最大缓存对象数，若是0表示无穷大
+       diskPersistent是否缓存虚拟机重启期数据
+       diskExpiryThreadIntervalSeconds磁盘失效线程运行时间间隔，默认是120秒
+       diskSpoolBufferSizeMB这个参数设置DiskStore（磁盘缓存）的缓存区大小。默认是30MB。每个Cache都应该有自己的一个缓冲区
+       memoryStoreEvictionPolicy当达到maxElementsInMemory限制时，Ehcache将会根据指定的策略去清理内存。默认策略是LRU（最近最少使用）。你可以设置为FIFO（先进先出）或是LFU（较少使用）
+-->
     <defaultCache
             eternal="false"
             maxElementsInMemory="1000"
@@ -11,13 +25,52 @@
             timeToLiveSeconds="600"
             memoryStoreEvictionPolicy="LRU" />
 
-    <cache
-            name="ehCache"
+    <cache  name="ehCache"
             eternal="false"
             maxElementsInMemory="1000"
             overflowToDisk="false"
             diskPersistent="false"
-            timeToIdleSeconds="0"
-            timeToLiveSeconds="300"
+            timeToIdleSeconds="864000"
+            timeToLiveSeconds="0"
             memoryStoreEvictionPolicy="LRU" />
+
+    <!--验证码缓存 2分钟的有效期-->
+    <cache  name="captchaCache"
+            eternal="false"
+            maxElementsInMemory="1000"
+            overflowToDisk="false"
+            diskPersistent="false"
+            timeToIdleSeconds="120"
+            timeToLiveSeconds="0"
+            memoryStoreEvictionPolicy="LRU" />
+
+    <!--令牌有效期 默认30分钟-->
+    <cache  name="tokenCache"
+            eternal="false"
+            maxElementsInMemory="1000"
+            overflowToDisk="false"
+            diskPersistent="false"
+            timeToIdleSeconds="1800"
+            timeToLiveSeconds="0"
+            memoryStoreEvictionPolicy="LRU" />
+    
+    <!--重复提交缓存 默认有效期5s-->
+    <cache  name="repeatSubmitCache"
+            eternal="false"
+            maxElementsInMemory="1000"
+            overflowToDisk="false"
+            diskPersistent="false"
+            timeToIdleSeconds="5"
+            timeToLiveSeconds="0"
+            memoryStoreEvictionPolicy="LRU" />
+
+    <!--登录账户密码错误次数缓存 默认有效期10分钟-->
+    <cache  name="pwdErrCntCache"
+            eternal="false"
+            maxElementsInMemory="1000"
+            overflowToDisk="false"
+            diskPersistent="false"
+            timeToIdleSeconds="600"
+            timeToLiveSeconds="0"
+            memoryStoreEvictionPolicy="LRU" />   
 </ehcache>

--- a/ruoyi-common/src/main/java/com/ruoyi/common/annotation/RepeatSubmit.java
+++ b/ruoyi-common/src/main/java/com/ruoyi/common/annotation/RepeatSubmit.java
@@ -16,6 +16,7 @@ public @interface RepeatSubmit
 {
     /**
      * 间隔时间(ms)，小于此时间视为重复提交
+     * 若修改需要更新ehCache.xml的repeatSubmitCache过期时间
      */
     public int interval() default 5000;
 

--- a/ruoyi-common/src/main/java/com/ruoyi/common/constant/Constants.java
+++ b/ruoyi-common/src/main/java/com/ruoyi/common/constant/Constants.java
@@ -65,7 +65,7 @@ public class Constants
     public static final String LOGIN_FAIL = "Error";
  
     /**
-     * 验证码有效期（分钟）
+     * 验证码有效期（分钟）（若修改需要更新ehCache.xml的captchaCache过期时间）
      */
     public static final Integer CAPTCHA_EXPIRATION = 2;
 
@@ -78,6 +78,14 @@ public class Constants
      * 默认的ehcache名称
      */
     public static final String DEFAULT_EHCACHE = "ehCache";
+    //验证码缓存 有效期默认2分钟
+    public static final String CAPTCH_EHCACHE = "captchaCache";
+    //令牌缓存 有效期默认30分钟
+    public static final String TOKEN_EHCACHE = "tokenCache";
+    //重复提交缓存 有效期5s
+    public static final String REPEAT_SUBMIT_EHCACHE = "repeatSubmitCache";
+    //登录账户密码错误次数缓存 默认有效期10分钟
+    public static final String PWD_ERR_CNT_EHCACHE = "pwdErrCntCache";
 
     /**
      * 令牌前缀

--- a/ruoyi-common/src/main/java/com/ruoyi/common/utils/CacheUtils.java
+++ b/ruoyi-common/src/main/java/com/ruoyi/common/utils/CacheUtils.java
@@ -8,14 +8,21 @@ import net.sf.ehcache.Cache;
 import net.sf.ehcache.CacheManager;
 import net.sf.ehcache.Element;
 
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 /**
  * 缓存处理
  *
- * @author ruoyi
+ * @author ligaoyuan
  */
 public class CacheUtils {
+    //在线用户缓存keys
+    private static Set<String> tokenCacheKeys = new HashSet<>();
+    //参数配置缓存keys
+    private static Set<String> sysConfigCacheKeys = new HashSet<>();
+
     /**
      * 设置缓存
      *
@@ -23,16 +30,17 @@ public class CacheUtils {
      * @param value    值
      * @param timeout  超时时间
      * @param timeUnit 时间单位
+     * @param cacheName ehCache的缓存名称                
      */
-    public static void putCache(String key, Object value, Integer timeout, TimeUnit timeUnit) {
+    public static void putCacheObject(String key, Object value, Integer timeout, TimeUnit timeUnit, String cacheName) {
         if (!RuoYiConfig.isEhCacheEnabled()) {
             SpringUtils.getBean(RedisCache.class).setCacheObject(key, value, timeout, timeUnit);
         } else {
-            //TODO 重复提交有5000ms的有效期
-            //TODO 令牌有30min的有效期
-            //TODO 验证码有2min的有效期
-            //TODO 密码锁定时间有10min的有效期
-            Cache cache = SpringUtils.getBean(CacheManager.class).getCache(Constants.DEFAULT_EHCACHE);
+            //重复提交有5000ms的有效期
+            //令牌有30min的有效期
+            //验证码有2min的有效期
+            //密码锁定时间有10min的有效期
+            Cache cache = SpringUtils.getBean(CacheManager.class).getCache(cacheName);
             Element element = new Element(key, value);
             cache.put(element);
         }
@@ -45,8 +53,19 @@ public class CacheUtils {
      * @param key   键
      * @param value 值
      */
-    public static void putCache(String key, Object value) {
-        if (!RuoYiConfig.isEhCacheEnabled()) {
+    public static void putCacheObject(String key, Object value) {
+        putCacheObject(key, value, RuoYiConfig.isEhCacheEnabled());
+    }
+
+    /**
+     * 设置缓存
+     *
+     * @param key   键
+     * @param value 值
+     * @param ehCacheEnabled 是否开启ehCache缓存             
+     */
+    public static void putCacheObject(String key, Object value, boolean ehCacheEnabled) {
+        if (!ehCacheEnabled) {
             SpringUtils.getBean(RedisCache.class).setCacheObject(key, value);
         } else {
             Cache cache = SpringUtils.getBean(CacheManager.class).getCache(Constants.DEFAULT_EHCACHE);
@@ -60,11 +79,20 @@ public class CacheUtils {
      *
      * @param key 键
      */
-    public static <T> T getCache(String key) {
+    public static <T> T getCacheObject(String key) {
+        return getCacheObject(key, Constants.DEFAULT_EHCACHE);
+    }
+
+    /**
+     * 获取缓存
+     *
+     * @param key 键
+     */
+    public static <T> T getCacheObject(String key, String cacheName) {
         if (!RuoYiConfig.isEhCacheEnabled()) {
             return SpringUtils.getBean(RedisCache.class).getCacheObject(key);
         } else {
-            Cache cache = SpringUtils.getBean(CacheManager.class).getCache(Constants.DEFAULT_EHCACHE);
+            Cache cache = SpringUtils.getBean(CacheManager.class).getCache(cacheName);
             Element element = cache.get(key);
             if (element != null) {
                 return (T) element.getObjectValue();
@@ -80,12 +108,58 @@ public class CacheUtils {
      *
      * @param key 键
      */
-    public static void deleteCache(String key) {
+    public static void deleteCacheObject(String key) {
         if (!RuoYiConfig.isEhCacheEnabled()) {
             SpringUtils.getBean(RedisCache.class).deleteObject(key);
         } else {
             Cache cache = SpringUtils.getBean(CacheManager.class).getCache(Constants.DEFAULT_EHCACHE);
             cache.remove(key);
         }
+    }
+
+    /**
+     * 增加在线用户缓存key
+     * @param key 键值
+     */
+    public static void addTokenCacheKey(String key) {
+        tokenCacheKeys.add(key);
+    }
+
+    /**
+     * 删除在线用户缓存key
+     * @param key 键值
+     */
+    public static void removeTokenCacheKey(String key) {
+        tokenCacheKeys.remove(key);
+    }
+
+    /**
+     * 获取在线用户缓存keys
+     */
+    public static Set<String> getTokenCacheKeys() {
+        return tokenCacheKeys;
+    }
+
+    /**
+     * 增加参数配置缓存key
+     * @param key 键值
+     */
+    public static void addConfigCacheKey(String key) {
+        sysConfigCacheKeys.add(key);
+    }
+
+    /**
+     * 删除参数配置缓存key
+     * @param key 键值
+     */
+    public static void removeConfigCacheKey(String key) {
+        sysConfigCacheKeys.remove(key);
+    }
+
+    /**
+     * 获取参数配置缓存keys
+     */
+    public static Set<String> getConfigCacheKeys() {
+        return sysConfigCacheKeys;
     }
 }

--- a/ruoyi-common/src/main/java/com/ruoyi/common/utils/DictUtils.java
+++ b/ruoyi-common/src/main/java/com/ruoyi/common/utils/DictUtils.java
@@ -30,7 +30,19 @@ public class DictUtils
      */
     public static void setDictCache(String key, List<SysDictData> dictDatas)
     {
-        CacheUtils.putCache(getCacheKey(key), dictDatas);
+        CacheUtils.putCacheObject(getCacheKey(key), dictDatas);
+    }
+
+    /**
+     * 设置字典缓存
+     *
+     * @param key 参数键
+     * @param dictDatas 字典数据列表
+     * @param ehCacheEnabled 是否开启ehCache缓存 
+     */
+    public static void setDictCache(String key, List<SysDictData> dictDatas, boolean ehCacheEnabled)
+    {
+        CacheUtils.putCacheObject(getCacheKey(key), dictDatas, ehCacheEnabled);
     }
 
     /**
@@ -40,9 +52,14 @@ public class DictUtils
      * @return dictDatas 字典数据列表
      */
     public static List<SysDictData> getDictCache(String key) {
-        JSONArray arrayCache = CacheUtils.getCache(getCacheKey(key));
-        if (StringUtils.isNotNull(arrayCache)) {
-            return arrayCache.toList(SysDictData.class);
+        Object cacheData = CacheUtils.getCacheObject(getCacheKey(key));
+        if (!RuoYiConfig.isEhCacheEnabled()) {
+            JSONArray arrayCache = (JSONArray) cacheData;
+            if (StringUtils.isNotNull(arrayCache)) {
+                return arrayCache.toList(SysDictData.class);
+            }
+        } else {
+            return (List<SysDictData>) cacheData;
         }
 
         return null;
@@ -162,7 +179,7 @@ public class DictUtils
      */
     public static void removeDictCache(String key)
     {
-        CacheUtils.deleteCache(getCacheKey(key));
+        CacheUtils.deleteCacheObject(getCacheKey(key));
     }
 
     /**

--- a/ruoyi-framework/src/main/java/com/ruoyi/framework/interceptor/impl/SameUrlDataInterceptor.java
+++ b/ruoyi-framework/src/main/java/com/ruoyi/framework/interceptor/impl/SameUrlDataInterceptor.java
@@ -3,6 +3,7 @@ package com.ruoyi.framework.interceptor.impl;
 import com.alibaba.fastjson2.JSON;
 import com.ruoyi.common.annotation.RepeatSubmit;
 import com.ruoyi.common.constant.CacheConstants;
+import com.ruoyi.common.constant.Constants;
 import com.ruoyi.common.filter.RepeatedlyRequestWrapper;
 import com.ruoyi.common.utils.CacheUtils;
 import com.ruoyi.common.utils.StringUtils;
@@ -33,9 +34,6 @@ public class SameUrlDataInterceptor extends RepeatSubmitInterceptor
     @Value("${token.header}")
     private String header;
 
-  /*@Autowired
-    private RedisCache redisCache;*/
-
     @SuppressWarnings("unchecked")
     @Override
     public boolean isRepeatSubmit(HttpServletRequest request, RepeatSubmit annotation)
@@ -65,7 +63,7 @@ public class SameUrlDataInterceptor extends RepeatSubmitInterceptor
         // 唯一标识（指定key + url + 消息头）
         String cacheRepeatKey = CacheConstants.REPEAT_SUBMIT_KEY + url + submitKey;
 
-        Object sessionObj = CacheUtils.getCache(cacheRepeatKey);
+        Object sessionObj = CacheUtils.getCacheObject(cacheRepeatKey, Constants.REPEAT_SUBMIT_EHCACHE);
         if (sessionObj != null)
         {
             Map<String, Object> sessionMap = (Map<String, Object>) sessionObj;
@@ -81,7 +79,7 @@ public class SameUrlDataInterceptor extends RepeatSubmitInterceptor
         Map<String, Object> cacheMap = new HashMap<String, Object>();
         cacheMap.put(url, nowDataMap);
 
-        CacheUtils.putCache(cacheRepeatKey, cacheMap, annotation.interval(), TimeUnit.MILLISECONDS);
+        CacheUtils.putCacheObject(cacheRepeatKey, cacheMap, annotation.interval(), TimeUnit.MILLISECONDS, Constants.REPEAT_SUBMIT_EHCACHE);
         return false;
     }
 

--- a/ruoyi-framework/src/main/java/com/ruoyi/framework/web/service/SysLoginService.java
+++ b/ruoyi-framework/src/main/java/com/ruoyi/framework/web/service/SysLoginService.java
@@ -37,9 +37,6 @@ public class SysLoginService
 
     @Resource
     private AuthenticationManager authenticationManager;
-
-/*    @Autowired
-    private RedisCache redisCache;*/
     
     @Autowired
     private ISysUserService userService;
@@ -109,8 +106,8 @@ public class SysLoginService
     {
         String verifyKey = CacheConstants.CAPTCHA_CODE_KEY + StringUtils.nvl(uuid, "");
         
-        String captcha = CacheUtils.getCache(verifyKey);
-        CacheUtils.deleteCache(verifyKey);
+        String captcha = CacheUtils.getCacheObject(verifyKey, Constants.CAPTCH_EHCACHE);
+        CacheUtils.deleteCacheObject(verifyKey);
         if (captcha == null)
         {
             AsyncManager.me().execute(AsyncFactory.recordLogininfor(username, Constants.LOGIN_FAIL, MessageUtils.message("user.jcaptcha.expire")));

--- a/ruoyi-framework/src/main/java/com/ruoyi/framework/web/service/SysPasswordService.java
+++ b/ruoyi-framework/src/main/java/com/ruoyi/framework/web/service/SysPasswordService.java
@@ -25,9 +25,6 @@ import java.util.concurrent.TimeUnit;
 @Component
 public class SysPasswordService
 {
-    /*@Autowired
-    private RedisCache redisCache;*/
-
     @Value(value = "${user.password.maxRetryCount}")
     private int maxRetryCount;
 
@@ -51,7 +48,7 @@ public class SysPasswordService
         String username = usernamePasswordAuthenticationToken.getName();
         String password = usernamePasswordAuthenticationToken.getCredentials().toString();
 
-        Integer retryCount = CacheUtils.getCache(getCacheKey(username));
+        Integer retryCount = CacheUtils.getCacheObject(getCacheKey(username), Constants.PWD_ERR_CNT_EHCACHE);
 
         if (retryCount == null)
         {
@@ -70,7 +67,7 @@ public class SysPasswordService
             retryCount = retryCount + 1;
             AsyncManager.me().execute(AsyncFactory.recordLogininfor(username, Constants.LOGIN_FAIL,
                     MessageUtils.message("user.password.retry.limit.count", retryCount)));
-            CacheUtils.putCache(getCacheKey(username), retryCount, lockTime, TimeUnit.MINUTES);
+            CacheUtils.putCacheObject(getCacheKey(username), retryCount, lockTime, TimeUnit.MINUTES, Constants.PWD_ERR_CNT_EHCACHE);
             throw new UserPasswordNotMatchException();
         }
         else
@@ -86,6 +83,6 @@ public class SysPasswordService
 
     public void clearLoginRecordCache(String loginName)
     {
-        CacheUtils.deleteCache(getCacheKey(loginName));
+        CacheUtils.deleteCacheObject(getCacheKey(loginName));
     }
 }

--- a/ruoyi-framework/src/main/java/com/ruoyi/framework/web/service/SysRegisterService.java
+++ b/ruoyi-framework/src/main/java/com/ruoyi/framework/web/service/SysRegisterService.java
@@ -31,9 +31,6 @@ public class SysRegisterService
 
     @Autowired
     private ISysConfigService configService;
-/*
-    @Autowired
-    private RedisCache redisCache;*/
 
     /**
      * 注册
@@ -101,8 +98,8 @@ public class SysRegisterService
     public void validateCaptcha(String username, String code, String uuid)
     {
         String verifyKey = CacheConstants.CAPTCHA_CODE_KEY + StringUtils.nvl(uuid, "");
-        String captcha = CacheUtils.getCache(verifyKey);
-        CacheUtils.deleteCache(verifyKey);
+        String captcha = CacheUtils.getCacheObject(verifyKey, Constants.CAPTCH_EHCACHE);
+        CacheUtils.deleteCacheObject(verifyKey);
         
         if (captcha == null)
         {

--- a/ruoyi-framework/src/main/java/com/ruoyi/framework/web/service/TokenService.java
+++ b/ruoyi-framework/src/main/java/com/ruoyi/framework/web/service/TokenService.java
@@ -17,8 +17,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import javax.servlet.http.HttpServletRequest;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -47,11 +46,6 @@ public class TokenService
 
     private static final Long MILLIS_MINUTE_TEN = 20 * 60 * 1000L;
 
-/*
-    @Autowired
-    private RedisCache redisCache;
-*/
-
     /**
      * 获取用户身份信息
      *
@@ -69,7 +63,7 @@ public class TokenService
                 // 解析对应的权限以及用户信息
                 String uuid = (String) claims.get(Constants.LOGIN_USER_KEY);
                 String userKey = getTokenKey(uuid);
-                return CacheUtils.getCache(userKey);
+                return CacheUtils.getCacheObject(userKey, Constants.TOKEN_EHCACHE);
             }
             catch (Exception e)
             {
@@ -97,7 +91,8 @@ public class TokenService
         if (StringUtils.isNotEmpty(token))
         {
             String userKey = getTokenKey(token);
-            CacheUtils.deleteCache(userKey);
+            CacheUtils.removeTokenCacheKey(userKey);
+            CacheUtils.deleteCacheObject(userKey);
         }
     }
 
@@ -146,7 +141,8 @@ public class TokenService
         loginUser.setExpireTime(loginUser.getLoginTime() + expireTime * MILLIS_MINUTE);
         // 根据uuid将loginUser缓存
         String userKey = getTokenKey(loginUser.getToken());
-        CacheUtils.putCache(userKey, loginUser, expireTime, TimeUnit.MINUTES);
+        CacheUtils.addTokenCacheKey(userKey);
+        CacheUtils.putCacheObject(userKey, loginUser, expireTime, TimeUnit.MINUTES, Constants.TOKEN_EHCACHE);
     }
 
     /**


### PR DESCRIPTION
1.ehCache增加验证码缓存,令牌缓存,重复提交缓存,登录账户密码错误次数缓存 用于配置特定的缓存失效时间 
2.更新清空参数缓存clearConfigCache()和获取在线用户信息getTokenCacheKeys(),因为ehCache不支持通配符*获取缓存key值，增加获取key的方法
 3.更新初始化字典缓存loadingDictCache()和初始化参数缓存loadingConfigCache()
 4.获取字典缓存getDictCache()类型转换抛错bug修改